### PR TITLE
Update BoI-2023 to point to the archive

### DIFF
--- a/data/conferences-regional.csv
+++ b/data/conferences-regional.csv
@@ -1,6 +1,6 @@
 name,location,date_start,date_end,link
 Biometrics in the Bush Capital,"Canberra, ACT, Australia","2025-11-23","2025-11-29",https://ibs-ar.github.io/conference2025/
-Biometrics in the Bay of Islands,"Bays of Island, Waitangi, New Zealand","2023-11-28","2023-12-01",https://biometricsboi.nz/
+Biometrics in the Bay of Islands,"Bays of Island, Waitangi, New Zealand","2023-11-28","2023-12-01",https://biometricsociety.org.au/archive/conferences/boi2023/index.html
 Biometrics by the Botanic Gardens,"Adelaide, SA, Australia","2019-12-03","2019-12-06",https://ausbiometric2019.netlify.app/
 Biometrics by the Border,"Kingscliff, NSW, Australia","2017-11-26","2017-11-30",https://biometricsociety.org.au/archive/conferences/Kingscliff2017/biometric2017.org/index.html
 Biometrics by the Harbour,"Hobart, TAS, Australia","2015-11-29","2015-12-03",https://biometricsociety.org.au/archive/conferences/Hobart2015/index.html


### PR DESCRIPTION
Updates the BoI 2023 conference URL to point to the archive. Note that this assumes that the https://github.com/IBS-AR/archive/pull/2 PR has been accepted.